### PR TITLE
Translate "lost and found" page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ playbook.log
 playbook.pdf
 playbook.aux
 playbook.synctex.gz
+playbook.out

--- a/playbook.tex
+++ b/playbook.tex
@@ -52,20 +52,22 @@ pdfauthor={\GroupName},
 
 \begin{titlepage}
 \begin{center}
-\TitlePageLineBold{18pt}{18pt}{Dieser Text gehört:} 
+\TitlePageLineBold{18pt}{18pt}{This playbook belongs to:} 
 \vspace{1.25cm}
 \textcolor{SignatureLineColor}{\rule{1\textwidth}{0.8pt}}
 
-\TitlePageLine{18pt}{18pt}{Mitglied des} 
+\TitlePageLine{18pt}{18pt}{Member of} 
 \TitlePageLineBold{36pt}{36pt}{\GroupName,}
-\TitlePageLine{18pt}{18pt}{der am} 
-\TitlePageLineBold{36pt}{36pt}{10. + 11. Januar 2020}
-\TitlePageLine{18pt}{18pt}{im} 
-\TitlePageLineBold{36pt}{36pt}{MZ der RUB}
-\TitlePageLine{24pt}{36pt}{das Stück “\PlayTitle” von Heinrich von Kleist aufführt.}
-\TitlePageLineBold{36pt}{36pt}{Eintritt frei!}
+\TitlePageLine{18pt}{18pt}{which you will be able to see on} 
+\TitlePageLineBold{36pt}{36pt}{February 29 and 30, 1337}
+\TitlePageLine{18pt}{18pt}{on} 
+\TitlePageLineBold{36pt}{36pt}{Planet Earth}
+\TitlePageLine{24pt}{36pt}{performing the play “\PlayTitle” by William Shakesapple.}
+\TitlePageLineBold{36pt}{36pt}{Admission free!}
 \vspace{2.5cm}
-\TitlePageLine{18pt}{27pt}{Falls Sie diesen Text finden, würden wir uns sehr freuen, wenn Sie ihn im Musischen Zentrum der RUB abgeben \mbox{} oder eine Mail an \setuldepth{info}\href{mailto:info@chaostrub.de}{\ul{info@chaostrub.de}} schreiben würden.}
+\TitlePageLine{18pt}{27pt}{In case you find this playbook, we would be very grateful if you were to return it to planet earth or send an email to
+\setuldepth{text without dee* letters}% Prevent underline to be too deep if email adress contains deep letters (such as p or q)
+\href{mailto:best-play-on-earth@example.com}{\ul{best-play-on-earth@example.com}}.}
 \end{center}
 \end{titlepage}
 


### PR DESCRIPTION
The first page (that mostly serves the service of informing the playbook's potential finder of who it belongs to and how it can be returned) used to be in German and contain information specific to the [ChaosTRUB](http://chaostrub.de). This PR translates that page into English and replaces the specific information with more general and (hopefully) funny information.